### PR TITLE
minor error fixed in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ PyYAML==6.0
 pyzmq==23.2.1
 regex==2022.8.17
 requests==2.28.1
-six @ file:///AppleInternal/BuildRoot/Library/Caches/com.apple.xbs/Sources/python3/python3-110/six-1.15.0-py2.py3-none-any.whl
+six==1.16.0
 smart-open==5.2.1
 spacy==3.4.1
 spacy-alignments==0.8.5


### PR DESCRIPTION
Made a minor correction to remove the six package filepath from requirements.txt. If the correct package is not six==1.16.0, then please change to correct version